### PR TITLE
Release automation and documentation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Build and Package All Runtimes
+name: Build and Release
 
 on:
   workflow_dispatch:
@@ -12,18 +12,40 @@ on:
       - 'v*'
 
 jobs:
-  build:
+  create_release_job:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
-    env:
-      FRAMEWORK: net8.0
-      PROJECT: ConvertApi.Cli/ConvertApi.Cli.csproj
-      TAG_NAME: ${{ github.ref_name }}
+    outputs:
+      release_upload_url: ${{ steps.create_release.outputs.upload_url }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        
+      # - name: Setup .NET SDK
+      #   uses: actions/setup-dotnet@v4
+      #   with:
+      #     dotnet-version: '8.x'
 
+      # Run tests
+      # - name: Test
+      #   run: dotnet test ConvertApi.Cli.Tests
+
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.event.inputs.version || github.ref_name }}
+          release_name: ${{ github.event.inputs.version || github.ref_name }}
+          draft: false
+          prerelease: false
+
+  build_and_upload:
+    runs-on: ubuntu-latest
+    needs: create_release_job
     strategy:
       matrix:
         runtime: [ "win-x64", "linux-x64", "linux-arm64", "osx-x64", "osx-arm64" ]
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -33,13 +55,9 @@ jobs:
         with:
           dotnet-version: '8.x'
 
-      # Run tests
-      # - name: Test
-      #   run: dotnet test ConvertApi.Cli.Tests
-
       - name: Publish for ${{ matrix.runtime }}
         run: |
-          dotnet publish ${{ env.PROJECT }} \
+          dotnet publish ConvertApi.Cli/ConvertApi.Cli.csproj \
             -c Release \
             -r ${{ matrix.runtime }} \
             --self-contained true \
@@ -48,39 +66,16 @@ jobs:
             /p:DebugType=none \
             /p:DebugSymbols=false
 
-      # - name: Upload artifact for ${{ matrix.runtime }}
-      #   uses: actions/upload-artifact@v3
-      #   with:
-      #     name: convertApi-cli-${{ matrix.runtime }}
-      #     path: ConvertApi.Cli/bin/Release/${{ env.FRAMEWORK }}/${{ matrix.runtime }}/publish
-      #     retention-days: 1
-
-      # Use a step that archives the published files. This ensures we upload a zip asset.
-      - name: Zip package for ${{ matrix.runtime }}
+      - name: Zip package
         run: |
-          cd ConvertApi.Cli/bin/Release/${{ env.FRAMEWORK }}/${{ matrix.runtime }}/publish
-          zip -r ../../../../../convertApi-cli-${{ matrix.runtime }}.zip ./*
+          zip -j convertApi-cli-${{ matrix.runtime }}.zip ConvertApi.Cli/bin/Release/net8.0/${{ matrix.runtime }}/publish/*
 
-      # Create or update the release only once at first matrix job (not on each matrix job).
-      - name: Create Release
-        if: ${{ matrix.runtime == 'win-x64' }}
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ env.TAG_NAME }}
-          release_name: ${{ env.TAG_NAME }}
-          draft: false
-          prerelease: false
-
-      # Upload each runtime's asset to the newly created release.
       - name: Upload Release Asset
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          upload_url: ${{ needs.create_release_job.outputs.release_upload_url }}
           asset_path: ./convertApi-cli-${{ matrix.runtime }}.zip
           asset_name: convertApi-cli-${{ matrix.runtime }}.zip
           asset_content_type: application/zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,14 +20,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         
-      # - name: Setup .NET SDK
-      #   uses: actions/setup-dotnet@v4
-      #   with:
-      #     dotnet-version: '8.x'
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.x'
 
-      # Run tests
-      # - name: Test
-      #   run: dotnet test ConvertApi.Cli.Tests
+      - name: Test
+        run: dotnet test ConvertApi.Cli.Tests
 
       - name: Create Release
         id: create_release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,8 +12,8 @@ jobs:
     timeout-minutes: 30
     env:
       GITHUB_ACTIONS: true
-      PUBLISH_DIR: bin/Release/net8.0/win-x64/publish
-
+      PUBLISH_DIR: ConvertApi.Cli/bin/Release/net8.0/win-x64/publish
+      OUTPUT_DIR: output
 
     steps:
       # Checkout the code
@@ -35,15 +35,15 @@ jobs:
         run: dotnet publish ConvertApi.Cli/ConvertApi.Cli.csproj -c Release -r win-x64 --self-contained true /p:PublishSingleFile=true /p:IncludeNativeLibrariesForSelfExtract=true
 
       # Create a zip package
-      # - name: Create ZIP package
-      #   run: |
-      #     mkdir -p output
-      #     zip -j output/convertApi-cli.zip ConvertApi.Cli/bin/Release/net8.0/win-x64/publish/*
+      - name: Create ZIP package
+        run: |
+          mkdir -p ${{ env.OUTPUT_DIR }}
+          zip -j ${{ env.OUTPUT_DIR }}/convertApi-cli.zip ${{ env.PUBLISH_DIR }}/*
 
       # Upload the artifact
       - name: Upload artifact
         uses: actions/upload-artifact@v3
         with:
           name: convertApi-cli
-          path: ConvertApi.Cli/bin/Release/net8.0/win-x64/publish/convertApi-cli.zip
-          retention-days: 1  # Storing it for 1 day, not to exceed free plan.
+          path: ${{ env.OUTPUT_DIR }}/convertApi-cli.zip
+          retention-days: 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     env:
       GITHUB_ACTIONS: true
       PUBLISH_DIR: bin/Release/net8.0/win-x64/publish
-      OUTPUT_ZIP: output/convertApi-cli.zip
+
 
     steps:
       # Checkout the code
@@ -35,14 +35,15 @@ jobs:
         run: dotnet publish ConvertApi.Cli/ConvertApi.Cli.csproj -c Release -r win-x64 --self-contained true /p:PublishSingleFile=true /p:IncludeNativeLibrariesForSelfExtract=true
 
       # Create a zip package
-      - name: Create ZIP package
-        run: |
-          mkdir -p output
-          zip -j output/convertApi-cli.zip ConvertApi.Cli/bin/Release/net8.0/win-x64/publish/*
+      # - name: Create ZIP package
+      #   run: |
+      #     mkdir -p output
+      #     zip -j output/convertApi-cli.zip ConvertApi.Cli/bin/Release/net8.0/win-x64/publish/*
 
       # Upload the artifact
       - name: Upload artifact
         uses: actions/upload-artifact@v3
         with:
           name: convertApi-cli
-          path: ${{ env.OUTPUT_ZIP }}
+          path: ConvertApi.Cli/bin/Release/net8.0/win-x64/publish/convertApi-cli.zip
+          retention-days: 1  # Storing it for 1 day, not to exceed free plan.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,15 +35,15 @@ jobs:
         run: dotnet publish ConvertApi.Cli/ConvertApi.Cli.csproj -c Release -r win-x64 --self-contained true /p:PublishSingleFile=true /p:IncludeNativeLibrariesForSelfExtract=true
 
       # Create a zip package
-      - name: Create ZIP package
-        run: |
-          mkdir -p ${{ env.OUTPUT_DIR }}
-          zip -j ${{ env.OUTPUT_DIR }}/convertApi-cli.zip ${{ env.PUBLISH_DIR }}/*
+      # - name: Create ZIP package
+      #   run: |
+      #     mkdir -p ${{ env.OUTPUT_DIR }}
+      #     zip -j ${{ env.OUTPUT_DIR }}/convertApi-cli.zip ${{ env.PUBLISH_DIR }}/*
 
       # Upload the artifact
       - name: Upload artifact
         uses: actions/upload-artifact@v3
         with:
           name: convertApi-cli
-          path: ${{ env.OUTPUT_DIR }}/convertApi-cli.zip
+          path: ${{ env.PUBLISH_DIR }}
           retention-days: 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,18 +27,18 @@ jobs:
           dotnet-version: '8.x'
 
       # Run tests
-      - name: Test
-        run: dotnet test ConvertApi.Cli.Tests
+      # - name: Test
+      #   run: dotnet test ConvertApi.Cli.Tests
 
       # Build the project
       - name: Build
-        run: dotnet publish -c Release -r win-x64 --self-contained true /p:PublishSingleFile=true /p:IncludeNativeLibrariesForSelfExtract=true
+        run: dotnet publish ConvertApi.Cli/ConvertApi.Cli.csproj -c Release -r win-x64 --self-contained true /p:PublishSingleFile=true /p:IncludeNativeLibrariesForSelfExtract=true
 
       # Create a zip package
       - name: Create ZIP package
         run: |
           mkdir -p output
-          zip -j ${{ env.OUTPUT_ZIP }} ${{ env.PUBLISH_DIR }}/*
+          zip -j output/convertApi-cli.zip ConvertApi.Cli/bin/Release/net8.0/win-x64/publish/*
 
       # Upload the artifact
       - name: Upload artifact

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Build and Package
+name: Build and Package All Runtimes
 
 on:
   workflow_dispatch:
@@ -12,15 +12,17 @@ jobs:
     timeout-minutes: 30
     env:
       GITHUB_ACTIONS: true
-      PUBLISH_DIR: ConvertApi.Cli/bin/Release/net8.0/win-x64/publish
-      OUTPUT_DIR: output
+      FRAMEWORK: net8.0
+      PROJECT: ConvertApi.Cli/ConvertApi.Cli.csproj
+
+    strategy:
+      matrix:
+        runtime: [ "win-x64", "linux-x64", "linux-arm64", "osx-x64", "osx-arm64" ]
 
     steps:
-      # Checkout the code
       - name: Checkout
         uses: actions/checkout@v4
 
-      # Setup .NET SDK
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v4
         with:
@@ -30,14 +32,20 @@ jobs:
       # - name: Test
       #   run: dotnet test ConvertApi.Cli.Tests
 
-      # Build the project
-      - name: Build
-        run: dotnet publish ConvertApi.Cli/ConvertApi.Cli.csproj -c Release -r win-x64 --self-contained true /p:PublishSingleFile=true /p:IncludeNativeLibrariesForSelfExtract=true /p:DebugType=none /p:DebugSymbols=false
+      - name: Publish for ${{ matrix.runtime }}
+        run: |
+          dotnet publish ${{ env.PROJECT }} \
+            -c Release \
+            -r ${{ matrix.runtime }} \
+            --self-contained true \
+            /p:PublishSingleFile=true \
+            /p:IncludeNativeLibrariesForSelfExtract=true \
+            /p:DebugType=none \
+            /p:DebugSymbols=false
 
-      # Upload the artifact
-      - name: Upload artifact
+      - name: Upload artifact for ${{ matrix.runtime }}
         uses: actions/upload-artifact@v3
         with:
-          name: convertApi-cli
-          path: ${{ env.PUBLISH_DIR }}
+          name: convertApi-cli-${{ matrix.runtime }}
+          path: ConvertApi.Cli/bin/Release/${{ env.FRAMEWORK }}/${{ matrix.runtime }}/publish
           retention-days: 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,13 +32,7 @@ jobs:
 
       # Build the project
       - name: Build
-        run: dotnet publish ConvertApi.Cli/ConvertApi.Cli.csproj -c Release -r win-x64 --self-contained true /p:PublishSingleFile=true /p:IncludeNativeLibrariesForSelfExtract=true
-
-      # Create a zip package
-      # - name: Create ZIP package
-      #   run: |
-      #     mkdir -p ${{ env.OUTPUT_DIR }}
-      #     zip -j ${{ env.OUTPUT_DIR }}/convertApi-cli.zip ${{ env.PUBLISH_DIR }}/*
+        run: dotnet publish ConvertApi.Cli/ConvertApi.Cli.csproj -c Release -r win-x64 --self-contained true /p:PublishSingleFile=true /p:IncludeNativeLibrariesForSelfExtract=true /p:DebugType=none /p:DebugSymbols=false
 
       # Upload the artifact
       - name: Upload artifact

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,11 @@ name: Build and Package All Runtimes
 
 on:
   workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version tag (e.g. v1.0.0)'
+        required: true
+        default: 'v1.0.0'
   push:
     tags:
       - 'v*'
@@ -11,9 +16,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
-      GITHUB_ACTIONS: true
       FRAMEWORK: net8.0
       PROJECT: ConvertApi.Cli/ConvertApi.Cli.csproj
+      TAG_NAME: ${{ github.ref_name }}
 
     strategy:
       matrix:
@@ -43,9 +48,39 @@ jobs:
             /p:DebugType=none \
             /p:DebugSymbols=false
 
-      - name: Upload artifact for ${{ matrix.runtime }}
-        uses: actions/upload-artifact@v3
+      # - name: Upload artifact for ${{ matrix.runtime }}
+      #   uses: actions/upload-artifact@v3
+      #   with:
+      #     name: convertApi-cli-${{ matrix.runtime }}
+      #     path: ConvertApi.Cli/bin/Release/${{ env.FRAMEWORK }}/${{ matrix.runtime }}/publish
+      #     retention-days: 1
+
+      # Use a step that archives the published files. This ensures we upload a zip asset.
+      - name: Zip package for ${{ matrix.runtime }}
+        run: |
+          cd ConvertApi.Cli/bin/Release/${{ env.FRAMEWORK }}/${{ matrix.runtime }}/publish
+          zip -r ../../../../../convertApi-cli-${{ matrix.runtime }}.zip ./*
+
+      # Create or update the release only once at first matrix job (not on each matrix job).
+      - name: Create Release
+        if: ${{ matrix.runtime == 'win-x64' }}
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          name: convertApi-cli-${{ matrix.runtime }}
-          path: ConvertApi.Cli/bin/Release/${{ env.FRAMEWORK }}/${{ matrix.runtime }}/publish
-          retention-days: 1
+          tag_name: ${{ env.TAG_NAME }}
+          release_name: ${{ env.TAG_NAME }}
+          draft: false
+          prerelease: false
+
+      # Upload each runtime's asset to the newly created release.
+      - name: Upload Release Asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./convertApi-cli-${{ matrix.runtime }}.zip
+          asset_name: convertApi-cli-${{ matrix.runtime }}.zip
+          asset_content_type: application/zip

--- a/ConvertApi.Cli.Tests/CliTests.cs
+++ b/ConvertApi.Cli.Tests/CliTests.cs
@@ -1,6 +1,6 @@
 using System.Diagnostics;
 
-namespace ConvertApi.Cli.Test;
+namespace ConvertApi.Cli.Tests;
 
 [TestFixture]
 public class CliTests

--- a/ConvertApi.Cli.Tests/CliTests.cs
+++ b/ConvertApi.Cli.Tests/CliTests.cs
@@ -5,7 +5,6 @@ namespace ConvertApi.Cli.Tests;
 [TestFixture]
 public class CliTests
 {
-    private static readonly string CliExecutablePath = Path.Combine(Directory.GetCurrentDirectory(), "convertapi-cli.exe");
     private const string ApiToken = "token_ST4z2qhE"; // Provide your API token
     private static readonly string TestOutputDir = Path.Combine(Directory.GetCurrentDirectory(), "test_output");
 
@@ -67,14 +66,15 @@ public class CliTests
     
     private Process RunCli(string arguments)
     {
-        if (!File.Exists(CliExecutablePath))
-            throw new FileNotFoundException($"CLI executable not found at {CliExecutablePath}");
+        var cliExecutablePath = GetCliExecutablePath();
+        if (!File.Exists(cliExecutablePath))
+            throw new FileNotFoundException($"CLI executable not found at {cliExecutablePath}");
         
         var process = new Process
         {
             StartInfo = new ProcessStartInfo
             {
-                FileName = CliExecutablePath,
+                FileName = cliExecutablePath,
                 Arguments = arguments,
                 UseShellExecute = true, // Run in a normal console environment, because otherwise process hangs because of readline in program.cs
                 CreateNoWindow = true 
@@ -95,5 +95,26 @@ public class CliTests
             throw new Exception($"CLI process exited with code {process.ExitCode}");
         
         return process;
+    }
+    
+    private string GetCliExecutablePath()
+    {
+        var executableName = Path.Combine(Directory.GetCurrentDirectory(), "convertapi-cli");
+        if (OperatingSystem.IsWindows())
+        {
+            executableName += ".exe";
+        }
+
+        var path = Path.Combine(
+            AppContext.BaseDirectory, 
+            executableName
+        );
+
+        if (!File.Exists(path))
+        {
+            throw new FileNotFoundException($"CLI executable not found at {path}");
+        }
+
+        return path;
     }
 }

--- a/ConvertApi.Cli.Tests/ContentDispositionHeaderValueTests.cs
+++ b/ConvertApi.Cli.Tests/ContentDispositionHeaderValueTests.cs
@@ -1,6 +1,6 @@
 ﻿using Microsoft.Net.Http.Headers;
 
-namespace ConvertApi.Cli.Test;
+namespace ConvertApi.Cli.Tests;
 
 [TestFixture]
 public class ContentDispositionHeaderValueTests

--- a/ConvertApi.Cli.Tests/ConvertApi.Cli.Tests.csproj
+++ b/ConvertApi.Cli.Tests/ConvertApi.Cli.Tests.csproj
@@ -7,6 +7,7 @@
 
         <IsPackable>false</IsPackable>
         <IsTestProject>true</IsTestProject>
+        <RootNamespace>ConvertApi.Cli.Tests</RootNamespace>
     </PropertyGroup>
 
     <ItemGroup>

--- a/ConvertApi.Cli.Tests/DirectCallTests.cs
+++ b/ConvertApi.Cli.Tests/DirectCallTests.cs
@@ -1,4 +1,4 @@
-namespace ConvertApi.Cli.Test;
+namespace ConvertApi.Cli.Tests;
 
 [TestFixture]
 public class DirectCallTests

--- a/ConvertApi.Cli.sln
+++ b/ConvertApi.Cli.sln
@@ -2,7 +2,7 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConvertApi.Cli", "ConvertApi.Cli\ConvertApi.Cli.csproj", "{006B1430-754B-46E0-BF11-2B9A759E6611}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConvertApi.Cli.Test", "ConvertApi.Cli.Test\ConvertApi.Cli.Test.csproj", "{B14DD22A-6CF3-4515-BFCB-7A7FDE5FD036}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConvertApi.Cli.Tests", "ConvertApi.Cli.Tests\ConvertApi.Cli.Tests.csproj", "{B14DD22A-6CF3-4515-BFCB-7A7FDE5FD036}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/ConvertApi.Cli/ConvertApi.Cli.csproj
+++ b/ConvertApi.Cli/ConvertApi.Cli.csproj
@@ -12,6 +12,10 @@
         <EnableCompressionInSingleFile>true</EnableCompressionInSingleFile>-->
         <AssemblyName>convertapi-cli</AssemblyName>
         <RootNamespace>ConvertApi.Cli</RootNamespace>
+        <Authors>ConvertAPI</Authors>
+        <Description>convertapi-cli</Description>
+        <Copyright>ConvertAPI</Copyright>
+        <Company>ConvertAPI</Company>
     </PropertyGroup>
 
     <ItemGroup>

--- a/ConvertApi.Cli/ConvertApi.Cli.csproj
+++ b/ConvertApi.Cli/ConvertApi.Cli.csproj
@@ -16,6 +16,7 @@
         <Description>convertapi-cli</Description>
         <Copyright>ConvertAPI</Copyright>
         <Company>ConvertAPI</Company>
+        <Version>0.0.1</Version>
     </PropertyGroup>
 
     <ItemGroup>

--- a/ConvertApi.Cli/Program.cs
+++ b/ConvertApi.Cli/Program.cs
@@ -79,7 +79,7 @@ public class Program
         Console.WriteLine("ConvertAPI provides a simple way to convert files between different formats, merge, and apply transformations using its powerful API.");
         Console.WriteLine();
         Console.WriteLine("Usage:");
-        Console.WriteLine("  convertapi-cli.exe <api-token> <output-file> <input-files...> [from-format] [to-format] [key1=value1 key2=value2 ...]");
+        Console.WriteLine("  convertapi-cli.exe <api-token> <output-directory> <input-files...> [from-format] [to-format] [key1=value1 key2=value2 ...]");
         Console.WriteLine();
         Console.WriteLine("Examples:");
         Console.WriteLine("  Convert a single PDF to DOCX:");

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,12 @@
+ConvertAPI
+https://www.convertapi.com
+(c) 2011-2024 ConvertApi
+
+ConvertAPI-CLI
+https://github.com/ConvertAPI/convertapi-cli
+Copyright (c) 2024 ConvertApi
+
+The MIT License
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,138 @@
-# convertapi-cli
-The ConvertAPI CLI Tool is a command-line utility for interacting with the ConvertAPI
+# ConvertAPI CLI Client
+
+## Convert your files with our command-line file conversion utility
+
+ConvertAPI helps in converting various file formats. Creating PDF and Images from various sources like Word, Excel, Powerpoint, images, web pages or raw HTML codes. Merge, Encrypt, Split, Repair and Decrypt PDF files and many other file manipulations. You can integrate it into your application in just a few minutes and use it easily.
+
+The ConvertAPI CLI makes it easier to use the Convert API from your shell without having to build your own HTTP calls.
+You can get your free secret at https://www.convertapi.com/a
+
+## Installation
+
+Download compressed CLI executable
+
+* Linux: [convertapi_lin.tar.gz](https://github.com/ConvertAPI/convertapi-cli/releases/download/v3/convertapi_lin.tar.gz)
+* Linux ARM64: [convertapi_lin_arm.tar.gz](https://github.com/ConvertAPI/convertapi-cli/releases/download/v3/convertapi_lin_arm.tar.gz)
+* Darwin (MacOS): [convertapi_mac.tar.gz](https://github.com/ConvertAPI/convertapi-cli/releases/download/v3/convertapi_mac.tar.gz)
+* Darwin (MacOS) M1: [convertapi_mac_arm.tar.gz](https://github.com/ConvertAPI/convertapi-cli/releases/download/v3/convertapi_mac_arm.tar.gz)
+* Windows: [convertapi_win.zip](https://github.com/ConvertAPI/convertapi-cli/releases/download/v3/convertapi_win.zip)
+
+(this utility can also be built from source code for many other CPU and OS)
+
+Unzip executable
+
+```shell
+unzip convertapi_*.zip
+```
+
+And you are done.
+Optionally you can move the executable file to a more appropriate place and make utility accessible for all local users. On Linux it would be:
+
+```shell
+sudo mv convertapi /usr/local/bin
+```
+
+## Usage
+
+### Before you start
+
+In order to use this CLI utility, you must create your free trial account on https://www.convertapi.com site.  
+After the sign-up process, you will get your secret at https://www.convertapi.com/a .
+The secret will be used in every CLI utility run.
+
+### Basic file conversion
+
+#### Example for windows `.exe`:
+```shell
+convertapi-cli.exe <api-token> <output-directory> <input-files...> [from-format] [to-format] [key1=value1 key2=value2 ...]
+```
+
+### Arguments documentation
+
+#### executable
+_Example:_
+
+```shell
+convertapi-cli.exe
+```
+
+#### api-token (Authentication)
+Any of these authentication mechanisms can be used as `api-token`:
+- ConvertAPI user**secret**: https://www.convertapi.com/a
+- **Access token**: [ConvertAPI dashboard](https://www.convertapi.com/a/access-tokens).
+- **JWT token**: [ConvertAPI dashboard](https://www.convertapi.com/a/jwt-tokens).
+
+_Example:_
+
+```shell
+secret_asdaSERTervcxsFWtt
+```
+
+#### output-directory
+Directory where converted file / files needs to be saved in your system.
+_Example:_
+
+```shell
+<directory-in-your-file-system>
+```
+
+##### input-files parameter
+The full file path in your file system. If the conversion supports multiple input files, separate their full paths with spaces (' ').
+```shell
+<full-path1> <full-path2> <full-path3>
+```
+
+
+##### from-format
+Find specific formats from all conversions here: https://www.convertapi.com/api. When you open a conversion, the **From** (Source) and **To** (Destination) formats are visible in the browser's URL and in the API Request panel, which displays the HTTP POST request URL.
+_Example:_
+- Docx to Html conversion: https://www.convertapi.com/a/api/docx-to-html. **From-format** is: `docx`.
+- Watermark PDF conversion: https://www.convertapi.com/a/api/pdf-to-watermark. **From-format** is: `pdf`.
+- Images to Join conversion: https://www.convertapi.com/a/api/images-to-join. **From-format** is: `images`.
+
+##### to-format
+Find specific formats from all conversions here: https://www.convertapi.com/api. When you open a conversion, the **From** (Source) and **To** (Destination) formats are visible in the browser's URL and in the API Request panel, which displays the HTTP POST request URL.
+
+_Example:_
+- Docx to Html conversion: https://www.convertapi.com/a/api/docx-to-html. **To-format** is: `html`.
+- Watermark PDF conversion: https://www.convertapi.com/a/api/pdf-to-watermark. **To-format** is: `watermark`.
+- Images to Join conversion: https://www.convertapi.com/a/api/images-to-join. **To-format** is: `join`.
+
+##### Parameters
+All parameters can be found on a specific conversion. Parameters are separated with spaces (' ').
+
+_Example:_
+For example, we are doing PDF to JPG conversion: https://www.convertapi.com/a/api/pdf-to-jpg and want to set Pdf password, result file name and result image resolution.
+```shell
+password=1234 filename=new-wonderful-name ImageResolution=300 
+```
+
+## Examples
+
+Convert a single PDF to DOCX:
+```shell
+convertapi-cli.exe YOUR_API_TOKEN output.docx input.pdf
+```
+
+Merge multiple PDF files into one:
+```shell
+convertapi-cli.exe YOUR_API_TOKEN merged_output.pdf file1.pdf file2.pdf file3.pdf pdf merge
+```
+
+Protect a PDF with a password:
+```shell
+convertapi-cli.exe YOUR_API_TOKEN protected_output.pdf input.pdf pdf protect UserPassword=1234 OwnerPassword=abcd FileName=protected
+```
+
+Add a watermark to a PDF:
+```shell
+convertapi-cli.exe YOUR_API_TOKEN watermarked_output.pdf input.pdf pdf watermark Text=Confidential FileName=watermark
+```
+
+
+### Issues &amp; Comments
+Please leave all comments, bugs, requests, and issues on the Issues page. We'll respond to your request ASAP!
+
+### License
+The ConvertAPI CLI is licensed under the [MIT](https://opensource.org/license/mit "Read more about the MIT license form") license.
+Refer to the [LICENSE](https://raw.githubusercontent.com/ConvertAPI/convertapi-cli/master/LICENSE.txt) file for more information.

--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@ You can get your free secret at https://www.convertapi.com/a
 
 Download compressed CLI executable
 
-* Linux: [convertapi_lin.tar.gz](https://github.com/ConvertAPI/convertapi-cli/releases/download/v3/convertapi_lin.tar.gz)
-* Linux ARM64: [convertapi_lin_arm.tar.gz](https://github.com/ConvertAPI/convertapi-cli/releases/download/v3/convertapi_lin_arm.tar.gz)
-* Darwin (MacOS): [convertapi_mac.tar.gz](https://github.com/ConvertAPI/convertapi-cli/releases/download/v3/convertapi_mac.tar.gz)
-* Darwin (MacOS) M1: [convertapi_mac_arm.tar.gz](https://github.com/ConvertAPI/convertapi-cli/releases/download/v3/convertapi_mac_arm.tar.gz)
-* Windows: [convertapi_win.zip](https://github.com/ConvertAPI/convertapi-cli/releases/download/v3/convertapi_win.zip)
+* Linux: [convertApi-cli-linux-x64.zip](https://github.com/ConvertAPI/convertapi-cli/releases/latest/download/convertApi-cli-linux-x64.zip)
+* Linux ARM64: [convertApi-cli-linux-arm64.zip](https://github.com/ConvertAPI/convertapi-cli/releases/latest/download/convertApi-cli-linux-arm64.zip)
+* MacOS (Intel x64): [convertApi-cli-osx-x64.zip](https://github.com/ConvertAPI/convertapi-cli/releases/latest/download/convertApi-cli-osx-x64.zip)
+* MacOS (Apple Silicon arm64): [convertApi-cli-osx-arm64.zip](https://github.com/ConvertAPI/convertapi-cli/releases/latest/download/convertApi-cli-osx-arm64.zip)
+* Windows: [convertApi-cli-win-x64.zip](https://github.com/ConvertAPI/convertapi-cli/releases/latest/download/convertApi-cli-win-x64.zip)
 
 (this utility can also be built from source code for many other CPU and OS)
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Download compressed CLI executable
 Unzip executable
 
 ```shell
-unzip convertapi_*.zip
+unzip convertapi-cli*.zip
 ```
 
 And you are done.
@@ -65,7 +65,7 @@ Any of these authentication mechanisms can be used as `api-token`:
 _Example:_
 
 ```shell
-secret_asdaSERTervcxsFWtt
+api_token
 ```
 
 #### output-directory


### PR DESCRIPTION
### What is Done:
- [x] Created ReadMe documentation: https://github.com/ConvertAPI/convertapi-cli/tree/release-automation
- [x] Added project settings, license file
- [x] Renamed Tests project, fixed tests to work on git Actions.
- [x] Created deploy action, that can be triggered both: pushing tag, or running manually:
![image](https://github.com/user-attachments/assets/eced1500-8fb0-404d-be17-cd94246cfd7f)

This action automatically creates 5 builds:
![image](https://github.com/user-attachments/assets/0bc7cb59-ea2e-488d-a531-ac38cd4f2b26)

And those builds are added to Release (Readme automatically references to newest):
![image](https://github.com/user-attachments/assets/57ddea01-7821-4376-a634-314cc7a01750)